### PR TITLE
don't bundle mesa

### DIFF
--- a/easytag-appimage.sh
+++ b/easytag-appimage.sh
@@ -23,7 +23,7 @@ cp -v /usr/share/icons/hicolor/256x256/apps/easytag.png  ./.DirIcon
 # ADD LIBRARIES
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./sharun-aio
 chmod +x ./sharun-aio
-xvfb-run -a ./sharun-aio l -p -v -s -k          \
+xvfb-run -a ./sharun-aio l -p -v -e -s -k       \
 	/usr/bin/easytag                            \
 	"$SYSLIBS"/libvorbis*                       \
 	"$SYSLIBS"/libvogg*                         \

--- a/easytag-appimage.sh
+++ b/easytag-appimage.sh
@@ -23,7 +23,7 @@ cp -v /usr/share/icons/hicolor/256x256/apps/easytag.png  ./.DirIcon
 # ADD LIBRARIES
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./sharun-aio
 chmod +x ./sharun-aio
-xvfb-run -a ./sharun-aio l -p -v -e -s -k           \
+xvfb-run -a ./sharun-aio l -p -v -s -k          \
 	/usr/bin/easytag                            \
 	"$SYSLIBS"/libvorbis*                       \
 	"$SYSLIBS"/libvogg*                         \
@@ -33,6 +33,7 @@ xvfb-run -a ./sharun-aio l -p -v -e -s -k           \
 	"$SYSLIBS"/libwavpack*                      \
 	"$SYSLIBS"/libid3tag.so*                    \
 	"$SYSLIBS"/libXss.so*                       \
+	"$SYSLIBS"/gconv/*                          \
 	"$SYSLIBS"/gdk-pixbuf-*/*/loaders/*         \
 	"$SYSLIBS"/gio/modules/libdconfsettings.so  \
 	"$SYSLIBS"/pulseaudio/*

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -40,6 +40,9 @@ wget --retry-connrefused --tries=30 "$OPUS_URL"   -O  ./opus.pkg.tar.zst
 pacman -U --noconfirm ./*.pkg.tar.zst
 rm -f ./*.pkg.tar.zst
 
+# for some reason this app ends up opening mesa, but doesn't really need it?
+# why would a gtk3 app that edit audio files need mesa???
+pacman -Rsndd --noconfirm mesa
 
 echo "All done!"
 echo "---------------------------------------------------------------"

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -34,8 +34,8 @@ echo "Installing debloated pckages..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$LIBXML_URL" -O  ./libxml2.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$OPUS_URL"   -O  ./opus.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$LLVM_URL"   -O  ./llvm-libs.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$MESA_URL"   -O  ./mesa.pkg.tar.zst
+#wget --retry-connrefused --tries=30 "$LLVM_URL"   -O  ./llvm-libs.pkg.tar.zst
+#wget --retry-connrefused --tries=30 "$MESA_URL"   -O  ./mesa.pkg.tar.zst
 
 pacman -U --noconfirm ./*.pkg.tar.zst
 rm -f ./*.pkg.tar.zst


### PR DESCRIPTION
Why would a gtk3 app that edit audio files need mesa??? 

It dlopens the lib for something, but after testing on an alpine container without adding mesa it all works fine still, so wtf